### PR TITLE
DE-4902: fixing migration script because of default entries in table queries for column schedule

### DIFF
--- a/migrations/versions/7205816877ec_change_type_of_json_fields_from_varchar_.py
+++ b/migrations/versions/7205816877ec_change_type_of_json_fields_from_varchar_.py
@@ -19,6 +19,9 @@ depends_on = None
 
 def upgrade():
     connection = op.get_bind()
+    op.alter_column('queries', 'schedule',
+        server_default=None
+        )
     op.alter_column('queries', 'options',
         existing_type=sa.Text(),
         type_=JSONB(astext_type=sa.Text()),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description

The current state of our psql db is not allowing the migrations from redash 10.x.x. to 25.x.x, one issue is arising when applying revision `7205816877ec`

This revision is changing some column type from `text` to `jsonb`, but if the affected columns have a defined default value set, the revisions cannot be applied since default `text` values cannot be casted to `jsonb`.
We do have one default value defined in table `queries` for column `schedule`: 
 
```
postgres=> \d+ queries
                                                                       Table "public.queries"
        Column        |           Type           | Collation | Nullable |               Default               | Storage  | Compression | Stats target | Description
----------------------+--------------------------+-----------+----------+-------------------------------------+----------+-------------+--------------+-------------
 updated_at           | timestamp with time zone |           | not null |                                     | plain    |             |              |
 created_at           | timestamp with time zone |           | not null |                                     | plain    |             |              |
 id                   | integer                  |           | not null | nextval('queries_id_seq'::regclass) | plain    |             |              |
 version              | integer                  |           | not null |                                     | plain    |             |              |
 org_id               | integer                  |           | not null |                                     | plain    |             |              |
 data_source_id       | integer                  |           |          |                                     | plain    |             |              |
 latest_query_data_id | integer                  |           |          |                                     | plain    |             |              |
 name                 | character varying(255)   |           | not null |                                     | extended |             |              |
 description          | character varying(4096)  |           |          |                                     | extended |             |              |
 query                | text                     |           | not null |                                     | extended |             |              |
 query_hash           | character varying(32)    |           | not null |                                     | extended |             |              |
 api_key              | character varying(40)    |           | not null |                                     | extended |             |              |
 user_id              | integer                  |           | not null |                                     | plain    |             |              |
 last_modified_by_id  | integer                  |           |          |                                     | plain    |             |              |
 is_archived          | boolean                  |           | not null |                                     | plain    |             |              |
 is_draft             | boolean                  |           | not null |                                     | plain    |             |              |
 schedule_failures    | integer                  |           | not null |                                     | plain    |             |              |
 options              | text                     |           | not null |                                     | extended |             |              |
 search_vector        | tsvector                 |           |          |                                     | extended |             |              |
 tags                 | character varying[]      |           |          |                                     | extended |             |              |
 schedule             | text                     |           |          | '{}'::text                          | extended |             |              |
```

This PR is fixing the failing revision by first dropping default value for `schedule` column. 

Something like changing column type and adding an new default value in one statement doesn't work: 
```
op.alter_column('queries', 'schedule',
         existing_type=sa.Text(),
         type_=JSONB(astext_type=sa.Text()),
         nullable=True,
         postgresql_using='schedule::jsonb',
         server_default=sa.text("'{}'::jsonb")
         )
```
I tried in the migration code, it's failing and [this PR](https://github.com/getredash/redash/pull/7068/files) seems to confirm my findings.

I tried this migration on staging and here is the result on `queries` table:
```
                                                                       Table "public.queries"
        Column        |           Type           | Collation | Nullable |               Default               | Storage  | Compression | Stats target | Description
----------------------+--------------------------+-----------+----------+-------------------------------------+----------+-------------+--------------+-------------
 updated_at           | timestamp with time zone |           | not null |                                     | plain    |             |              |
 created_at           | timestamp with time zone |           | not null |                                     | plain    |             |              |
 id                   | integer                  |           | not null | nextval('queries_id_seq'::regclass) | plain    |             |              |
 version              | integer                  |           | not null |                                     | plain    |             |              |
 org_id               | integer                  |           | not null |                                     | plain    |             |              |
 data_source_id       | integer                  |           |          |                                     | plain    |             |              |
 latest_query_data_id | integer                  |           |          |                                     | plain    |             |              |
 name                 | character varying(255)   |           | not null |                                     | extended |             |              |
 description          | character varying(4096)  |           |          |                                     | extended |             |              |
 query                | text                     |           | not null |                                     | extended |             |              |
 query_hash           | character varying(32)    |           | not null |                                     | extended |             |              |
 api_key              | character varying(40)    |           | not null |                                     | extended |             |              |
 user_id              | integer                  |           | not null |                                     | plain    |             |              |
 last_modified_by_id  | integer                  |           |          |                                     | plain    |             |              |
 is_archived          | boolean                  |           | not null |                                     | plain    |             |              |
 is_draft             | boolean                  |           | not null |                                     | plain    |             |              |
 schedule_failures    | integer                  |           | not null |                                     | plain    |             |              |
 options              | jsonb                    |           |          |                                     | extended |             |              |
 search_vector        | tsvector                 |           |          |                                     | extended |             |              |
 tags                 | character varying[]      |           |          |                                     | extended |             |              |
 schedule             | jsonb                    |           |          |                                     | extended |             |              |
 ```

Useful links: 
- https://github.com/getredash/redash/issues/6706
- https://github.com/getredash/redash/issues/6836
