### PR TITLE
fix(client): Use JSON parser that works with big ints

### DIFF
--- a/client/app/services/axios.js
+++ b/client/app/services/axios.js
@@ -7,17 +7,17 @@ import { restoreSession } from "@/services/restoreSession";
 import { JSONParse } from "json-with-bigint/json-with-bigint.js";
 
 export const axios = axiosLib.create({
-  paramsSerializer: params => qs.stringify(params),
+  paramsSerializer: (params) => qs.stringify(params),
   xsrfCookieName: "csrf_token",
   xsrfHeaderName: "X-CSRF-TOKEN",
-  transformResponse: [data => JSONParse(data)],
+  transformResponse: [(data) => JSONParse(data)],
 });
 
-axios.interceptors.response.use(response => response.data);
+axios.interceptors.response.use((response) => response.data);
 
 export const csrfRefreshInterceptor = createAuthRefreshInterceptor(
   axios,
-  error => {
+  (error) => {
     const message = get(error, "response.data.message");
     if (error.isAxiosError && includes(message, "CSRF")) {
       return axios.get("/ping");
@@ -30,7 +30,7 @@ export const csrfRefreshInterceptor = createAuthRefreshInterceptor(
 
 export const sessionRefreshInterceptor = createAuthRefreshInterceptor(
   axios,
-  error => {
+  (error) => {
     const status = parseInt(get(error, "response.status"));
     const message = get(error, "response.data.message");
     // TODO: In axios@0.9.1 this check could be replaced with { skipAuthRefresh: true } flag. See axios-auth-refresh docs
@@ -46,7 +46,7 @@ export const sessionRefreshInterceptor = createAuthRefreshInterceptor(
   }
 );
 
-axios.interceptors.request.use(config => {
+axios.interceptors.request.use((config) => {
   const apiKey = Auth.getApiKey();
   if (apiKey) {
     config.headers.Authorization = `Key ${apiKey}`;

--- a/client/app/services/axios.js
+++ b/client/app/services/axios.js
@@ -4,11 +4,13 @@ import createAuthRefreshInterceptor from "axios-auth-refresh";
 import { Auth } from "@/services/auth";
 import qs from "query-string";
 import { restoreSession } from "@/services/restoreSession";
+import { JSONParse } from "json-with-bigint/json-with-bigint.js";
 
 export const axios = axiosLib.create({
   paramsSerializer: params => qs.stringify(params),
   xsrfCookieName: "csrf_token",
   xsrfHeaderName: "X-CSRF-TOKEN",
+  transformResponse: [data => JSONParse(data)],
 });
 
 axios.interceptors.response.use(response => response.data);

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "font-awesome": "^4.7.0",
     "history": "^4.10.1",
     "hoist-non-react-statics": "^3.3.0",
+    "json-with-bigint": "^3.4.4",
     "markdown": "0.5.0",
     "material-design-iconic-font": "^2.2.0",
     "mousetrap": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9040,6 +9040,11 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
+json-with-bigint@^3.4.4:
+  version "3.4.4"
+  resolved "https://wooga.jfrog.io/wooga/api/npm/npmbi/json-with-bigint/-/json-with-bigint-3.4.4.tgz#ef798afee4c4203feffa44f5238cd77c93e8f72a"
+  integrity sha512-AhpYAAaZsPjU7smaBomDt1SOQshi9rEm6BlTbfVwsG1vNmeHKtEedJi62sHZzJTyKNtwzmNnrsd55kjwJ7054A==
+
 json2mq@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/json2mq/-/json2mq-0.2.0.tgz#b637bd3ba9eabe122c83e9720483aeb10d2c904a"


### PR DESCRIPTION

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description

The default JSON.parse used by axios does not work well with big numbers and will trunctate them. To fix this we replace the parser used by axios by a JSON parser that does work with big numbers.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

Query any datasource for a large number, e.g.:

```
SELECT 12345678901234567;
```

You will see an incorrect number in the result:

```
12345678901234568 
```

After applying this fix the resulting number will be the same as originally queried.

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
