### PR TITLE
chore(yarn): Fix yarn registry for json-with-bigint

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9042,7 +9042,7 @@ json-stringify-safe@~5.0.1:
 
 json-with-bigint@^3.4.4:
   version "3.4.4"
-  resolved "https://wooga.jfrog.io/wooga/api/npm/npmbi/json-with-bigint/-/json-with-bigint-3.4.4.tgz#ef798afee4c4203feffa44f5238cd77c93e8f72a"
+  resolved "https://registry.yarnpkg.com/json-with-bigint/-/json-with-bigint-3.4.4.tgz#ef798afee4c4203feffa44f5238cd77c93e8f72a"
   integrity sha512-AhpYAAaZsPjU7smaBomDt1SOQshi9rEm6BlTbfVwsG1vNmeHKtEedJi62sHZzJTyKNtwzmNnrsd55kjwJ7054A==
 
 json2mq@^0.2.0:


### PR DESCRIPTION
Tested locally and this seems to fix the issue.

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
